### PR TITLE
Expose ephemeral helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,15 @@ import Web3Context from './context/Web3Context';
 import { useWeb3Injected, useWeb3Network, useWeb3 } from './react/useWeb3Hook';
 import { useEphemeralKey } from './react/useEphemeralKeyHook';
 import { fromInjected, fromConnection } from './context/factory';
+import { ephemeral } from './wallet/keys';
 
-export { Web3Context, fromInjected, fromConnection, useWeb3Injected, useWeb3Network, useWeb3, useEphemeralKey };
+export {
+  Web3Context,
+  fromInjected,
+  fromConnection,
+  useWeb3Injected,
+  useWeb3Network,
+  useWeb3,
+  useEphemeralKey,
+  ephemeral,
+};


### PR DESCRIPTION
We are listing it in the docs to use gsn without react, but it is not exposed anywhere.