### PR TITLE
Fix install on Windows and network/react import

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "docs": "oz-docs",
     "docs:watch": "npm run docs watch",
     "lint": "npx tsc --noEmit && eslint 'src/**/*.{js,ts}' --fix",
-    "preinstall": "ln -s ./lib/react ./react",
     "prepare": "npm run compile",
     "test": "jest --verbose",
     "watch": "tsc -w"

--- a/react/index.js
+++ b/react/index.js
@@ -1,0 +1,7 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const react = __importDefault(require("../lib/react"));
+exports = react;


### PR DESCRIPTION
This PR focuses on fixing #27 (issues related to build on Windows).

### Problems
1. First there is an issue regarding the **preinstall** script: it assumes **lib** directory is present, however, it is not if the project has never been built. Which prevents it from being built at the first place. At a first attempt, I moved this to an **install** script (=post install) but ended up removing the symlink of the react subfolder all together.

2. In fact, the **ln** command makes it complicated to install on Windows, one replacement could be to consider using a package like **shx** though, I went for another solution for now.

3. Even if the symlink creation works, at the end it is going to fail because (at least on Windows) paths from the symlink folder are resolved at the path of the symlink itself. 
For example, **lib/react/useWeb3Hook.js** attempts to require **../context/providers**, which works well from **lib/react** but not from the actual symlink location.

### Solutions
To keep it consistent and allow to import the react implementation using this nice path: "@openzeppelin/network/react"

1. Removed symlink command all together 
2. Added a wrapper script in **./react** to import (= link) **./lib/react** at the root directory

### Other
Wondering if there is another solution to solve the import problem... but for now this has been working on my side. This has been tested on Win with cmd and also a bash shell.
